### PR TITLE
Mostly PEP8 fixes, one bugfix, and a feature addition.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.python-version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/rachiopy/__init__.py
+++ b/rachiopy/__init__.py
@@ -33,11 +33,8 @@ class Rachio(object):
         (resp, content) = _HTTP.request(url, method,
                                         headers=self._headers, body=body)
 
-        status = resp.get('status')
         content_type = resp.get('content-type')
-        if status != '200':
-            content = None
-        elif content_type == 'application/json':
+        if content_type and content_type.startswith('application/json'):
             content = json.loads(content.decode('UTF-8'))
 
         return (resp, content)

--- a/rachiopy/__init__.py
+++ b/rachiopy/__init__.py
@@ -1,3 +1,6 @@
+"""Main rachiopy module"""
+
+import json
 import httplib2
 
 from rachiopy.person import Person
@@ -7,18 +10,52 @@ from rachiopy.schedulerule import Schedulerule
 from rachiopy.flexschedulerule import FlexSchedulerule
 from rachiopy.notification import Notification
 
-class Rachio(object):
-	def __init__(self, authtoken):
-		self.server = 'https://api.rach.io/1/public/'
-		self.headers = {
-			'Content-Type': 'application/json',
-			'Authorization': 'Bearer %s' % authtoken
-			}
-		self.h = httplib2.Http('.cache')
+_SERVER = 'https://api.rach.io/1/public'
+_HTTP = httplib2.Http('.cache')
 
-		self.person = Person(self)
-		self.device = Device(self)
-		self.zone = Zone(self)
-		self.schedulerule = Schedulerule(self)
-		self.flexschedulerule = FlexSchedulerule(self)
-		self.notification = Notification(self)
+#pylint: disable=too-many-instance-attributes
+class Rachio(object):
+    """Represent the Rachio API."""
+    def __init__(self, authtoken):
+        self._headers = {'Content-Type': 'application/json',
+                         'Authorization': 'Bearer %s' % authtoken}
+
+        self.person = Person(self)
+        self.device = Device(self)
+        self.zone = Zone(self)
+        self.schedulerule = Schedulerule(self)
+        self.flexschedulerule = FlexSchedulerule(self)
+        self.notification = Notification(self)
+
+    def _request(self, path, method, body=None):
+        """Make a request from the API."""
+        url = '/'.join([_SERVER, path])
+        (resp, content) = _HTTP.request(url, method,
+                                        headers=self._headers, body=body)
+
+        status = resp.get('status')
+        content_type = resp.get('content-type')
+        if status != '200':
+            content = None
+        elif content_type == 'application/json':
+            content = json.loads(content.decode('UTF-8'))
+
+        return (resp, content)
+
+    def get(self, path):
+        """Make a GET request from the API."""
+        return self._request(path, 'GET')
+
+    def delete(self, path):
+        """Make a DELETE request from the API."""
+        return self._request(path, 'DELETE')
+
+    def put(self, path, payload):
+        """Make a PUT request from the API."""
+        body = json.dumps(payload)
+        return self._request(path, 'PUT', body)
+
+    def post(self, path, payload):
+        """Make a POST request from the API."""
+        body = json.dumps(payload)
+        return self._request(path, 'POST', body)

--- a/rachiopy/__init__.py
+++ b/rachiopy/__init__.py
@@ -1,11 +1,11 @@
 import httplib2
 
-from person import Person
-from device import Device
-from zone import Zone
-from schedulerule import Schedulerule
-from flexschedulerule import FlexSchedulerule
-from notification import Notification
+from rachiopy.person import Person
+from rachiopy.device import Device
+from rachiopy.zone import Zone
+from rachiopy.schedulerule import Schedulerule
+from rachiopy.flexschedulerule import FlexSchedulerule
+from rachiopy.notification import Notification
 
 class Rachio(object):
 	def __init__(self, authtoken):

--- a/rachiopy/device.py
+++ b/rachiopy/device.py
@@ -1,63 +1,68 @@
-import json
+"""Device module handling /device/ API calls."""
+#pylint: disable=invalid-name
+
 
 class Device(object):
-	def __init__(self, rachio):
-		self.rachio = rachio
+    """Device class with /device/ API calls."""
+    def __init__(self, rachio):
+        self.rachio = rachio
 
-	def get(self, id):
-		url = '%sdevice/%s' % (self.rachio.server, id)
+    def get(self, dev_id):
+        """Retrieve the information for a device entity."""
+        path = '/'.join(['device', dev_id])
+        return self.rachio.get(path)
 
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
+    def getCurrentSchedule(self, dev_id):
+        """Retrieve current schedule running, if any."""
+        path = '/'.join(['device', dev_id, 'current_schedule'])
+        return self.rachio.get(path)
 
-	def getCurrentSchedule(self, id):
-		url = '%sdevice/%s/current_schedule' % (self.rachio.server, id)
+    def getEvent(self, dev_id, starttime, endtime):
+        """Retrieve events for a device entity."""
+        path = 'device/%s/event?startTime=%s&endTime=%s' % \
+            (dev_id, starttime, endtime)
+        return self.rachio.get(path)
 
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
+    def getScheduleItem(self, dev_id):
+        """
+        Retrieve the next two weeks of schedule items for a device entity.
+        """
+        path = '/'.join(['device', dev_id, 'scheduleitem'])
+        return self.rachio.get(path)
 
-	def getEvent(self, id, starttime, endtime):
-		url = '%sdevice/%s/event?startTime=%s&endTime=%s' % (self.rachio.server, id, starttime, endtime)
+    def getForecast(self, dev_id, units):
+        """Retrieve current and predicted forecast."""
+        assert units in ['US', 'METRIC'], \
+                'units must be either US or METRIC'
+        path = 'device/%s/forecast?units=%s' % (dev_id, units)
+        return self.rachio.get(path)
 
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
+    def stopWater(self, dev_id):
+        """Stop all watering on device."""
+        path = 'device/stop_water'
+        payload = {'id' : dev_id}
+        return self.rachio.put(path, payload)
 
-	def getScheduleItem(self, id):
-		url = '%sdevice/%s/scheduleitem' % (self.rachio.server, id)
+    def rainDelay(self, dev_id, duration):
+        """Rain delay device."""
+        path = 'device/rain_delay'
+        payload = {'id' : dev_id, 'duration' : duration}
+        return self.rachio.put(path, payload)
 
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
+    def on(self, dev_id):
+        """
+        Turn ON all features of the device (schedules, weather intelligence,
+        water budget, etc.).
+        """
+        path = 'device/on'
+        payload = {'id' : dev_id}
+        return self.rachio.put(path, payload)
 
-	def getForecast(self, id, units):
-		url = '%s%sdevice/%s/forecast?units=%s' % (self.rachio.server, id, units)
-
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
-
-	def stopWater(self, id):
-		url = '%sdevice/stop_water' % self.rachio.server
-		payload = {'id' : id } 
-
-		(resp, content) = self.rachio.h.request(url, 'PUT', body=json.dumps(payload), headers=self.rachio.headers)
-		return (resp, content)
-
-	def rainDelay(self, id, duration):
-		url = '%sdevice/rain_delay' % self.rachio.server
-		payload = { 'id' : id, 'duration' : duration }
-
-		(resp, content) = self.rachio.h.request(url, 'PUT', body=json.dumps(payload), headers=self.rachio.headers)
-		return (resp, content)
-
-	def on(self, id):
-		url = '%sdevice/on' % self.rachio.server
-		payload = { 'id' : id }
-
-		(resp, content) = self.rachio.h.request(url, 'PUT', body=json.dumps(payload), headers=self.rachio.headers)
-		return (resp, content)
-
-	def off(self, id):
-		url = '%sdevice/off' % self.rachio.server
-		payload = { 'id' : id }
-
-		(resp, content) = self.rachio.h.request(url, 'PUT', body=json.dumps(payload), headers=self.rachio.headers)
-		return (resp, content) 
+    def off(self, dev_id):
+        """
+        Turn OFF all features of the device (schedules, weather intelligence,
+        water budget, etc.).
+        """
+        path = 'device/off'
+        payload = {'id' : dev_id}
+        return self.rachio.put(path, payload)

--- a/rachiopy/flexschedulerule.py
+++ b/rachiopy/flexschedulerule.py
@@ -1,10 +1,16 @@
+"""Flexschedulerule module handling /flexschedulerule/ API calls."""
+#pylint: disable=invalid-name
+
+
 class FlexSchedulerule(object):
-	def __init__(self, rachio):
-		self.rachio = rachio
+    """
+    FlexSchedulerule class with methods for /flexschedulerule/ API calls.
+    """
+    #pylint: disable=too-few-public-methods
+    def __init__(self, rachio):
+        self.rachio = rachio
 
-	def get(self, id):
-		url = '%sflexschedulerule/%s' % (self.rachio.server, id)
-
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
-
+    def get(self, flex_sched_rule_id):
+        """Retrieve the information for a flexscheduleRule entity."""
+        path = '/'.join(['flexschedulerule', flex_sched_rule_id])
+        return self.rachio.get(path)

--- a/rachiopy/notification.py
+++ b/rachiopy/notification.py
@@ -1,43 +1,49 @@
-import json
+"""Notification module handling /notification/ API calls."""
+#pylint: disable=invalid-name
+
 
 class Notification(object):
-	def __init__(self, rachio):
-		self.rachio = rachio
+    """Notification class with methods for /notification/ API calls."""
+    def __init__(self, rachio):
+        self.rachio = rachio
 
-	def getWebhookEventType(self):
-		url = '%snotification/webhook_event_type' % self.rachio.server
+    def getWebhookEventType(self):
+        """
+        Retrieve the list of events types that are available to any webhook
+        for subscription.
+        """
+        path = 'notification/webhook_event_type'
+        return self.rachio.get(path)
 
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
+    def getDeviceWebhook(self, dev_id):
+        """Retrieve all webhooks for a device."""
+        path = '/'.join(['notification', dev_id, 'webhook'])
+        return self.rachio.get(path)
 
-	def getDeviceWebhook(self, id):
-		url = '%snotification/%s/webhook' % (self.rachio.server, id)
+    def postWebhook(self, dev_id, external_id, url, event_types):
+        """
+        Add a webhook to a device. externalId can be used as opaque data that
+        is tied to your company, and passed back in each webhook event
+        response.
+        """
+        path = 'notification/webhook'
+        payload = {'device': {'id': dev_id}, 'externalId': external_id,
+                   'url': url, 'eventTypes': event_types}
+        return self.rachio.post(path, payload)
 
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
+    def putWebhook(self, hook_id, external_id, url, event_types):
+        """Update a webhook."""
+        path = 'notification/webhook'
+        payload = {'id': hook_id, 'externalId': external_id,
+                   'url': url, 'eventTypes': event_types}
+        return self.rachio.put(path, payload)
 
-	def postWebhook(self, webhook):
-		url = '%snotification/webhook' % self.rachio.server
-		payload = {webhook}
+    def deleteWebhook(self, hook_id):
+        """Remove a webhook."""
+        path = '/'.join(['notification', 'webhook', hook_id])
+        return self.rachio.delete(path)
 
-		(resp, content) = self.rachio.h.request(url, 'POST', body=json.dumps(payload), headers=self.rachio.headers)
-		return (resp, content)
-
-	def putWebhook(self, webhook):
-		url = '%snotification/webhook' % self.rachio.server
-		payload = {webhook}
-
-		(resp, content) = self.rachio.h.request(url, 'PUT', body=json.dumps(payload), headers=self.rachio.headers)
-		return (resp, content)
-
-	def deleteWebhook(self, id):
-		url = '%snotification/webhook/%s' % (self.rachio.server, id)
-
-		(resp, content) = self.rachio.h.request(url, 'DELETE', headers=self.rachio.headers)
-		return (resp, content)
-
-	def get(self, id):
-		url = '%snotification/webhook/%s' % (self.rachio.server, id)
-
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
+    def get(self, hook_id):
+        """Get a webhook."""
+        path = '/'.join(['notification', 'webhook', hook_id])
+        return self.rachio.get(path)

--- a/rachiopy/person.py
+++ b/rachiopy/person.py
@@ -1,15 +1,21 @@
+"""Person module handling /person/ API calls."""
+#pylint: disable=invalid-name
+
+
 class Person(object):
-	def __init__(self, rachio):
-		self.rachio = rachio
+    """Person class with methods for /person/ API calls."""
+    def __init__(self, rachio):
+        self.rachio = rachio
 
-	def getInfo(self):
-		url = '%sperson/info' % (self.rachio.server)
+    def getInfo(self):
+        """
+        Retrieve the id for the person entity currently logged in
+        through OAuth.
+        """
+        path = 'person/info'
+        return self.rachio.get(path)
 
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
-
-	def get(self, id):
-		url = '%sperson/%s' % (self.rachio.server, id)
-
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
+    def get(self, user_id):
+        """Retrieve the information for a person entity."""
+        path = '/'.join(['person', user_id])
+        return self.rachio.get(path)

--- a/rachiopy/schedulerule.py
+++ b/rachiopy/schedulerule.py
@@ -1,33 +1,35 @@
-import json 
+"""Schedulerule module handling /scheduerule/ API calls."""
+#pylint: disable=invalid-name
+
 
 class Schedulerule(object):
-	def __init__(self, rachio):
-		self.rachio = rachio
+    """Schedulerule class with methods for /schedulerule/ API calls."""
+    def __init__(self, rachio):
+        self.rachio = rachio
 
-	def skip(self, id):
-		url = '%sschedulerule/skip' % self.rachio.server
-		payload = { 'id' : id }
+    def skip(self, sched_rule_id):
+        """Skip a schedule rule (watering time)."""
+        path = 'schedulerule/skip'
+        payload = {'id' : sched_rule_id}
+        return self.rachio.put(path, payload)
 
-		(resp, content) = self.rachio.h.request(url, 'PUT', body=json.dumps(payload), headers=self.rachio.headers)
-		return (resp, content)
+    def start(self, sched_rule_id):
+        """Start a schedule rule (watering time)."""
+        path = 'schedulerule/start'
+        payload = {'id': sched_rule_id}
+        return self.rachio.put(path, payload)
 
-	def start(self, id):
-		url = '%sschedulerule/start' % self.rachio.server
-		payload = { 'id': id }
+    def seasonalAdjustment(self, sched_rule_id, adjustment):
+        """
+        Seasonal adjustment for a schedule rule (watering time). This
+        adjustment amount will be applied to the overall run time of the
+        selected schedule while overriding any current adjustments.
+        """
+        path = 'schedulerule/seasonal_adjustment'
+        payload = {'id': sched_rule_id, 'adjustment': adjustment}
+        return self.rachio.put(path, payload)
 
-		(resp, content) = self.rachio.h.request(url, 'PUT', body=json.dumps(payload), headers=self.rachio.headers)
-		return (resp, content)
-
-	def seasonalAdjustment(self, id, adjustment):
-		url = '%sschedulerule/seasonal_adjustment' % self.rachio.server
-		payload = { 'id': id, 'adjustment': adjustment }
-
-		(resp, content) = self.rachio.h.request(url, 'PUT', body=json.dumps(payload), headers=self.rachio.headers)
-		return (resp, content)
-
-	def get(self, id):
-		url = '%sschedulerule/%s' % (self.rachio.server, id)
-
-		(resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-		return (resp, content)
-
+    def get(self, sched_rule_id):
+        """Retrieve the information for a scheduleRule entity."""
+        path = '/'.join(['schedulerule', sched_rule_id])
+        return self.rachio.get(path)

--- a/rachiopy/zone.py
+++ b/rachiopy/zone.py
@@ -1,25 +1,54 @@
-import json
+"""Zone module handling /zone/ API calls."""
+#pylint: disable=invalid-name
+
 
 class Zone(object):
+    """Zone class with methods for /zone/ API calls."""
     def __init__(self, rachio):
         self.rachio = rachio
 
-    def start(self, id, duration):
-        url = '%szone/start' % self.rachio.server
-        payload = {'id': id, 'duration': duration}
-
-        (resp, content) = self.rachio.h.request(url, 'PUT', body=json.dumps(payload), headers=self.rachio.headers)
-        return (resp, content)
+    def start(self, zone_id, duration):
+        """Start a zone."""
+        path = 'zone/start'
+        payload = {'id': zone_id, 'duration': duration}
+        return self.rachio.put(path, payload)
 
     def startMultiple(self, zones):
-        url = '%szone/start_multiple' % self.rachio.server
+        """Start multiple zones."""
+        path = 'zone/start_multiple'
         payload = {'zones': zones}
+        return self.rachio.put(path, payload)
 
-        (resp, content) = self.rachio.h.request(url, 'PUT', body=json.dumps(payload), headers=self.rachio.headers)
-        return (resp, content)
+    def schedule(self):
+        """Create an empty zone schedule."""
+        return ZoneSchedule(self)
 
-    def get(self, id):
-        url = '%szone/%s' % (self.rachio.server, id)
+    def get(self, zone_id):
+        """Retrieve the information for a zone entity."""
+        path = '/'.join(['zone', zone_id])
+        return self.rachio.get(path)
 
-        (resp, content) = self.rachio.h.request(url, 'GET', headers=self.rachio.headers)
-        return (resp, content)
+
+class ZoneSchedule(object):
+    """Help with starting multiple zones."""
+    def __init__(self, zone_api):
+        self._api = zone_api
+        self._zones = []
+
+    def enqueue(self, zone_id, duration):
+        """Add a zone and duration to the schedule."""
+        self._zones.append((zone_id, duration))
+
+    def start(self):
+        """Start the schedule."""
+        zones = [{"id": data[0], "duration": data[1], "sortOrder": count}
+                 for (count, data) in enumerate(self._zones, 1)]
+        self._api.startMultiple(zones)
+
+    def __enter__(self):
+        """Allow a schedule to be created in a with block."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Allow the schedule to be executed by leaving with block."""
+        self.start()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+"""Rachiopy setup script."""
 from setuptools import setup
 
 setup(
@@ -17,6 +18,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development',
         ]
-) 
+)


### PR DESCRIPTION
1) PEP8 changes were made throughout the code. All the required
docstrings were added and lines were limited to 80 characters. All the
tabs have been changed to spaces. Lower camel case method names have
been kept despite PEP8 rules. Minimal pylint exceptions were added and
now the code passes a pylint check.

2) Much of the code related to requests was put into the top level
class. The get, delete, put, and post methods removed a lot of
duplicated code throughout the library. The response form the API is
now parsed a bit as well. If a 200 response is given and JSON encoding
is indicated, the JSON will be parsed before returning. With this
change, the http handler and headers no longer needed to be used
outside of the main class. These were changed to private attributes.
JSON encoding of the payload is now done in the mail class removing the
need for importing son in other modules.

3) A ZoneScheduler class was created to assist with the
zone.startMultiple call. This class will create the proper data
structure needed for the API call. It has been designed to be used
inside a with block like so:
```python
with rachio.zone.schedule() as sched:

      sched.enqueue(zone_id[0], 5)

      sched.enqueue(zone_id[1], 10)

      sched.enqueue(zone_id[2], 15)
```
Alternatively:
```python
sched = rachio.zone.schedule()
sched.enqueue(zone_id[0], 5)

sched.enqueue(zone_id[1], 10)

sched.enqueue(zone_id[2], 15)
sched.start()
```

4) Bugfixes: Relative imports do not work the same way in Python 3 as they did in
Python 2. Full imports ensure compatibility between versions. Version number in setup.py must be a string.