### PR TITLE
Removed the caching from rachiopy

### DIFF
--- a/rachiopy/__init__.py
+++ b/rachiopy/__init__.py
@@ -11,7 +11,7 @@ from rachiopy.flexschedulerule import FlexSchedulerule
 from rachiopy.notification import Notification
 
 _SERVER = 'https://api.rach.io/1/public'
-_HTTP = httplib2.Http('.cache')
+_HTTP = httplib2.Http()
 
 #pylint: disable=too-many-instance-attributes
 class Rachio(object):


### PR DESCRIPTION
Caching breaked some usage of this packages because of the location the
.cache file was created. However, since the Rachio API returns a
Cache-Control header of no-cache, no-store, max-age=0, must-revalidate,
no-cache="set-cookie" caching isn't working. 

#8 